### PR TITLE
[Don't merge] Swap out gold sample for APOGEE DR17 unimodal sample (beta)

### DIFF
--- a/workflow/rules/data.smk
+++ b/workflow/rules/data.smk
@@ -1,5 +1,5 @@
 URLS = {
-    "gold_sample.fits": "https://users.flatironinstitute.org/~apricewhelan/data/dr16-binaries/gold_sample.fits",
+    "gold_sample.fits": "https://users.flatironinstitute.org/~apricewhelan/data/apogee/clean-unimodal-turbo20-beta.fits",
     "edr3-rv-good-plx-result.fits.gz": "https://users.flatironinstitute.org/~apricewhelan/data/edr3/edr3-rv-good-plx-result.fits.gz",
     "kepler_dr2_1arcsec.fits": "https://www.dropbox.com/s/xo1n12fxzgzybny/kepler_dr2_1arcsec.fits?dl=1",
     "SB9public.tar.gz": "https://sb9.astro.ulb.ac.be/SB9public.tar.gz",


### PR DESCRIPTION
This is an initial version of what will be the gold sample for the upcoming APOGEE data release (DR17). The MAP parameter values may be a little off here because I had some issues getting the MCMC sampling to work for all of the systems, but it is ~2x as many sources as the previous catalog, so I'm interested to see how things look! Since this is a beta version, we shouldn't switch to this for production, but hoping that CI will produce the figure I want to see 🙏?